### PR TITLE
cleanup, update clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,23 +24,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -81,24 +109,55 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crc32fast"
@@ -179,6 +238,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -339,6 +404,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,17 +476,19 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "syn"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
- "unicode-width",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -418,16 +503,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "unicode-ident"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "weezl"
@@ -436,23 +521,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 
 [dependencies]
 bufstream = "0.1"
-clap = "2.34"
+clap = { version = "4.4", features = [ "derive" ] }
 image = "0.23"
 num_cpus = "1.13.1"
 regex = "1.5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,0 @@
-// Application properties
-pub const APP_NAME: &str = "pixelpwnr";
-pub const APP_VERSION: &str = "0.1";
-pub const APP_AUTHOR: &str = "Tim Visee <timvisee@gmail.com>";
-pub const APP_ABOUT: &str = "A quick pixelflut client, that pwns pixelflut panels.";
-
-// The default frames per second rate
-pub const DEFAULT_IMAGE_FPS: u32 = 1;

--- a/src/arg_handler.rs
+++ b/src/arg_handler.rs
@@ -129,7 +129,7 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
 
     /// Get the image size.
     /// Use the given default value if not set.
-    pub fn size(&self, def: Option<(u32, u32)>) -> (u32, u32) {
+    pub fn size(&self, def: Option<(u16, u16)>) -> (u16, u16) {
         (
             self.matches
                 .value_of("width")
@@ -143,15 +143,15 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
     }
 
     /// Get the image offset.
-    pub fn offset(&self) -> (u32, u32) {
+    pub fn offset(&self) -> (u16, u16) {
         (
             self.matches
                 .value_of("x")
-                .map(|x| x.parse::<u32>().expect("Invalid X offset"))
+                .map(|x| x.parse::<u16>().expect("Invalid X offset"))
                 .unwrap_or(0),
             self.matches
                 .value_of("y")
-                .map(|y| y.parse::<u32>().expect("Invalid Y offset"))
+                .map(|y| y.parse::<u16>().expect("Invalid Y offset"))
                 .unwrap_or(0),
         )
     }

--- a/src/image_manager.rs
+++ b/src/image_manager.rs
@@ -28,7 +28,7 @@ impl ImageManager {
     }
 
     /// Instantiate the image manager, and load the images from the given paths.
-    pub fn load(paths: &[&str], size: (u32, u32)) -> ImageManager {
+    pub fn load(paths: &[&str], size: (u16, u16)) -> ImageManager {
         // Show a status message
         println!("Load and process {} image(s)...", paths.len());
 
@@ -84,7 +84,7 @@ impl ImageManager {
 }
 
 /// Load the image at the given path, and size it correctly
-fn load_image(path: &str, size: (u32, u32)) -> DynamicImage {
+fn load_image(path: &str, size: (u16, u16)) -> DynamicImage {
     // Create a path instance
     let path = Path::new(&path);
 
@@ -97,5 +97,5 @@ fn load_image(path: &str, size: (u32, u32)) -> DynamicImage {
     let image = image::open(&path).unwrap();
 
     // Resize the image to fit the screen
-    image.resize_exact(size.0, size.1, FilterType::Gaussian)
+    image.resize_exact(size.0 as u32, size.1 as u32, FilterType::Gaussian)
 }

--- a/src/image_manager.rs
+++ b/src/image_manager.rs
@@ -1,11 +1,11 @@
+use rayon::prelude::*;
 use std::path::Path;
 use std::thread::sleep;
 use std::time::Duration;
-use rayon::prelude::*;
 
 use image;
-use image::DynamicImage;
 use image::imageops::FilterType;
+use image::DynamicImage;
 
 use pix::canvas::Canvas;
 
@@ -33,8 +33,12 @@ impl ImageManager {
         println!("Load and process {} image(s)...", paths.len());
 
         // Load the images from the paths
-        let image_manager =
-            ImageManager::from(paths.par_iter().map(|path| load_image(path, size)).collect());
+        let image_manager = ImageManager::from(
+            paths
+                .par_iter()
+                .map(|path| load_image(path, size))
+                .collect(),
+        );
 
         // TODO: process the image slices
 

--- a/src/image_manager.rs
+++ b/src/image_manager.rs
@@ -98,7 +98,7 @@ fn load_image(path: &str, size: (u16, u16)) -> DynamicImage {
     }
 
     // Load the image
-    let image = image::open(&path).unwrap();
+    let image = image::open(path).unwrap();
 
     // Resize the image to fit the screen
     image.resize_exact(size.0 as u32, size.1 as u32, FilterType::Gaussian)

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn start<'a>(arg_handler: &ArgHandler<'a>) {
 }
 
 /// Gather important facts about the host.
-fn gather_host_facts(arg_handler: &ArgHandler) -> Result<(u32, u32), Error> {
+fn gather_host_facts(arg_handler: &ArgHandler) -> Result<(u16, u16), Error> {
     // Set up a client, and get the screen size
     let size = Client::connect(arg_handler.host().to_string(), false)?.read_screen_size()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ extern crate clap;
 extern crate image;
 extern crate rayon;
 
-mod app;
 mod arg_handler;
 mod color;
 mod image_manager;
@@ -27,7 +26,7 @@ fn main() {
 }
 
 /// Start pixelflutting.
-fn start<'a>(arg_handler: &ArgHandler<'a>) {
+fn start(arg_handler: &ArgHandler) {
     // Start
     println!("Starting... (use CTRL+C to stop)");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn start(arg_handler: &ArgHandler) {
 
     // Gather facts about the host
     let screen_size =
-        gather_host_facts(&arg_handler).expect("Failed to gather facts about pixelflut server");
+        gather_host_facts(arg_handler).expect("Failed to gather facts about pixelflut server");
 
     // Determine the size to use
     let size = arg_handler.size(Some(screen_size));

--- a/src/painter/handle.rs
+++ b/src/painter/handle.rs
@@ -31,7 +31,12 @@ impl Handle {
     /// Push an image update.
     pub fn update_image(&self, full_image: &mut DynamicImage) {
         // Crop the image to the area
-        let image = full_image.crop(self.area.x, self.area.y, self.area.w, self.area.h);
+        let image = full_image.crop(
+            self.area.x as u32,
+            self.area.y as u32,
+            self.area.w as u32,
+            self.area.h as u32,
+        );
 
         // Push a new image to the thread
         // TODO: return this result

--- a/src/painter/painter.rs
+++ b/src/painter/painter.rs
@@ -74,7 +74,6 @@ impl Painter {
                 // Define the color
                 let color = Color::from(channels[0], channels[1], channels[2], channels[3]);
 
-
                 // Set the pixel
                 if let Some(client) = &mut self.client {
                     client.write_pixel(

--- a/src/painter/painter.rs
+++ b/src/painter/painter.rs
@@ -11,7 +11,7 @@ use rect::Rect;
 pub struct Painter {
     client: Option<Client>,
     area: Rect,
-    offset: (u32, u32),
+    offset: (u16, u16),
     image: Option<DynamicImage>,
 }
 
@@ -20,7 +20,7 @@ impl Painter {
     pub fn new(
         client: Option<Client>,
         area: Rect,
-        offset: (u32, u32),
+        offset: (u16, u16),
         image: Option<DynamicImage>,
     ) -> Painter {
         Painter {
@@ -62,7 +62,7 @@ impl Painter {
                 }
 
                 // Get the pixel at this location
-                let pixel = image.get_pixel(x, y);
+                let pixel = image.get_pixel(x as u32, y as u32);
 
                 // Get the channels
                 let channels = pixel.channels();

--- a/src/pix/canvas.rs
+++ b/src/pix/canvas.rs
@@ -15,8 +15,8 @@ pub struct Canvas {
     host: String,
     painter_count: usize,
     painter_handles: Vec<Handle>,
-    size: (u32, u32),
-    offset: (u32, u32),
+    size: (u16, u16),
+    offset: (u16, u16),
 }
 
 impl Canvas {
@@ -24,8 +24,8 @@ impl Canvas {
     pub fn new(
         host: &str,
         painter_count: usize,
-        size: (u32, u32),
-        offset: (u32, u32),
+        size: (u16, u16),
+        offset: (u16, u16),
         binary: bool,
     ) -> Canvas {
         // Initialize the object
@@ -52,10 +52,10 @@ impl Canvas {
         // Spawn some painters
         for i in 0..self.painter_count {
             // Determine the slice width
-            let width = self.size.0 / (self.painter_count as u32);
+            let width = self.size.0 / (self.painter_count as u16);
 
             // Define the area to paint per thread
-            let painter_area = Rect::from((i as u32) * width, 0, width, self.size.1);
+            let painter_area = Rect::from((i as u16) * width, 0, width, self.size.1);
 
             // Spawn the painter
             self.spawn_painter(painter_area, binary);

--- a/src/pix/canvas.rs
+++ b/src/pix/canvas.rs
@@ -79,26 +79,23 @@ impl Canvas {
             let mut painter = Painter::new(None, area, offset, None);
 
             loop {
-                // The painting loop
-                'paint: loop {
-                    // Connect
-                    let client = match Client::connect(host.clone(), binary) {
-                        Ok(client) => client,
-                        Err(e) => {
-                            eprintln!("Painter failed to connect: {}", e);
-                            break 'paint;
-                        }
-                    };
-                    painter.set_client(Some(client));
+                // Connect
+                match Client::connect(host.clone(), binary) {
+                    Ok(client) => {
+                        painter.set_client(Some(client));
 
-                    // Keep painting
-                    loop {
-                        if let Err(e) = painter.work(&rx) {
-                            println!("Painter error: {}", e);
-                            break 'paint;
+                        // Keep painting
+                        loop {
+                            if let Err(e) = painter.work(&rx) {
+                                println!("Painter error: {}", e);
+                                break;
+                            }
                         }
                     }
-                }
+                    Err(e) => {
+                        eprintln!("Painter failed to connect: {}", e);
+                    }
+                };
 
                 // Sleep for half a second before restarting the painter
                 sleep(Duration::from_millis(500));

--- a/src/pix/client.rs
+++ b/src/pix/client.rs
@@ -48,7 +48,7 @@ impl Client {
     }
 
     /// Write a pixel to the given stream.
-    pub fn write_pixel(&mut self, x: u32, y: u32, color: Color) -> Result<(), Error> {
+    pub fn write_pixel(&mut self, x: u16, y: u16, color: Color) -> Result<(), Error> {
         if self.binary {
             self.write_command(
                 &[
@@ -74,7 +74,7 @@ impl Client {
     }
 
     /// Read the size of the screen.
-    pub fn read_screen_size(&mut self) -> Result<(u32, u32), Error> {
+    pub fn read_screen_size(&mut self) -> Result<(u16, u16), Error> {
         // Read the screen size
         let data = self
             .write_read_command(b"SIZE")
@@ -87,10 +87,10 @@ impl Client {
         match re.captures(&data) {
             Some(matches) => Ok((
                 matches[1]
-                    .parse::<u32>()
+                    .parse::<u16>()
                     .expect("Failed to parse screen width, received malformed data"),
                 matches[2]
-                    .parse::<u32>()
+                    .parse::<u16>()
                     .expect("Failed to parse screen height, received malformed data"),
             )),
             None => Err(Error::new(

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,14 +2,14 @@
 #[derive(Copy, Clone)]
 pub struct Rect {
     // TODO: Make these properties private
-    pub x: u32,
-    pub y: u32,
-    pub w: u32,
-    pub h: u32,
+    pub x: u16,
+    pub y: u16,
+    pub w: u16,
+    pub h: u16,
 }
 
 impl Rect {
-    pub fn from(x: u32, y: u32, w: u32, h: u32) -> Rect {
+    pub fn from(x: u16, y: u16, w: u16, h: u16) -> Rect {
         Rect { x, y, w, h }
     }
 }


### PR DESCRIPTION
- The binary protocol only allows for `u16`s to be sent over the wire, so the data types should reflect this appropriately. (This should probably also be changed in the server.)
- Ensure that the endian-ness of the x and y coordinates in the binary protocol are always handled correctly. The server code parses the value as a little endian value, so the appropriate function is used for encoding.
- The version of `clap` used is updated (2.34 to current 4.4) and the argument parsing is now implemented using the derive facilities, since the code had to be rewritten anyway.
  The `app.rs` file is thus no longer needed because the app name etc. are taken from the definitions in `Cargo.toml` automatically. The `DEFAULT_IMAGE_FPS` is just inlined as a default value of 1.
  I'm not sure if it makes sense to continue using the `ArgHandler` wrapper, so I left it in for now.
- Fixed clippy lints and formatting.