### PR TITLE
Configure netwok package size and send multiple commands per package

### DIFF
--- a/src/arg_handler.rs
+++ b/src/arg_handler.rs
@@ -23,7 +23,8 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .help("The host to pwn \"host:port\"")
                     .required(true)
                     .index(1),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("image")
                     .short("i")
                     .long("image")
@@ -34,7 +35,8 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .multiple(true)
                     .display_order(1)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("width")
                     .short("w")
                     .long("width")
@@ -42,7 +44,8 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .help("Draw width (def: screen width)")
                     .display_order(2)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("height")
                     .short("h")
                     .long("height")
@@ -50,21 +53,24 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .help("Draw height (def: screen height)")
                     .display_order(3)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("x")
                     .short("x")
                     .value_name("PIXELS")
                     .help("Draw X offset (def: 0)")
                     .display_order(4)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("y")
                     .short("y")
                     .value_name("PIXELS")
                     .help("Draw Y offset (def: 0)")
                     .display_order(5)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("count")
                     .short("c")
                     .long("count")
@@ -74,7 +80,8 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .help("Number of concurrent threads (def: CPUs)")
                     .display_order(6)
                     .takes_value(true),
-            ).arg(
+            )
+            .arg(
                 Arg::with_name("fps")
                     .short("r")
                     .long("fps")
@@ -82,10 +89,28 @@ impl<'a: 'b, 'b> ArgHandler<'a> {
                     .help("Frames per second with multiple images (def: 1)")
                     .display_order(7)
                     .takes_value(true),
-            ).get_matches();
+            )
+            .arg(
+                Arg::with_name("packagesize")
+                    .short("ps")
+                    .long("packagesize")
+                    .value_name("PACKAGESIZE")
+                    .help("Package size of of transfered packages")
+                    .display_order(5)
+                    .takes_value(true),
+            )
+            .get_matches();
 
         // Instantiate
         ArgHandler { matches }
+    }
+
+    /// Get the image offset.
+    pub fn package_size(&self) -> u32 {
+        self.matches
+            .value_of("packagesize")
+            .map(|x| x.parse::<u32>().expect("Invalid package size"))
+            .unwrap_or(1500)
     }
 
     /// Get the host property.

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn start<'a>(arg_handler: &ArgHandler<'a>) {
         arg_handler.count(),
         size,
         arg_handler.offset(),
+        arg_handler.package_size(),
     );
 
     // Load the image manager

--- a/src/painter/painter.rs
+++ b/src/painter/painter.rs
@@ -85,6 +85,11 @@ impl Painter {
                 }
             }
         }
+        // if a frame is finished but the data should be sent
+        // No point in sending multiple frames in one package
+        if let Some(client) = &mut self.client {
+            client.flush()?;
+        }
 
         // Everything seems to be ok
         Ok(())

--- a/src/pix/canvas.rs
+++ b/src/pix/canvas.rs
@@ -76,13 +76,15 @@ impl Canvas {
                 // The painting loop
                 'paint: loop {
                     // Connect
-                    let client = match Client::connect(host.clone()) {
+                    let mut client = match Client::connect(host.clone()) {
                         Ok(client) => client,
                         Err(e) => {
                             eprintln!("Painter failed to connect: {}", e);
                             break 'paint;
-                        },
+                        }
                     };
+                    //TODO: get value from argument
+                    client.packet_size(1500);
                     painter.set_client(Some(client));
 
                     // Keep painting

--- a/src/pix/canvas.rs
+++ b/src/pix/canvas.rs
@@ -21,7 +21,13 @@ pub struct Canvas {
 
 impl Canvas {
     /// Create a new pixelflut canvas.
-    pub fn new(host: &str, painter_count: usize, size: (u32, u32), offset: (u32, u32)) -> Canvas {
+    pub fn new(
+        host: &str,
+        painter_count: usize,
+        size: (u32, u32),
+        offset: (u32, u32),
+        packet_size: u32,
+    ) -> Canvas {
         // Initialize the object
         let mut canvas = Canvas {
             host: host.to_string(),
@@ -35,14 +41,14 @@ impl Canvas {
         println!("Starting painter threads...");
 
         // Spawn some painters
-        canvas.spawn_painters();
+        canvas.spawn_painters(packet_size);
 
         // Return the canvas
         canvas
     }
 
     /// Spawn the painters for this canvas
-    fn spawn_painters(&mut self) {
+    fn spawn_painters(&mut self, packet_size: u32) {
         // Spawn some painters
         for i in 0..self.painter_count {
             // Determine the slice width
@@ -52,12 +58,12 @@ impl Canvas {
             let painter_area = Rect::from((i as u32) * width, 0, width, self.size.1);
 
             // Spawn the painter
-            self.spawn_painter(painter_area);
+            self.spawn_painter(painter_area, packet_size);
         }
     }
 
     /// Spawn a single painter in a thread.
-    fn spawn_painter(&mut self, area: Rect) {
+    fn spawn_painter(&mut self, area: Rect, packet_size: u32) {
         // Get the host that will be used
         let host = self.host.to_string();
 
@@ -83,8 +89,7 @@ impl Canvas {
                             break 'paint;
                         }
                     };
-                    //TODO: get value from argument
-                    client.packet_size(1500);
+                    client.packet_size(packet_size);
                     painter.set_client(Some(client));
 
                     // Keep painting


### PR DESCRIPTION
Currently, the code only sends 1 pixel per package. This is not very efficient. It would be far better to send as many commands as fit in one package.

This code allows configuring a package size per --packagesize argument and fills this packages with as many pixels as possible before sending.