### PR TITLE
Add manual (server) canvas size parameter

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -83,15 +83,8 @@ impl ArgHandler {
 
     /// Get the image size.
     /// Use the given default value if not set.
-    pub fn size(&self, def: Option<(u16, u16)>) -> (u16, u16) {
-        (
-            self.data
-                .width
-                .unwrap_or(def.expect("No screen width set or known").0),
-            self.data
-                .height
-                .unwrap_or(def.expect("No screen height set or known").1),
-        )
+    pub fn size(&self) -> (Option<u16>, Option<u16>) {
+        (self.data.width, self.data.height)
     }
 
     /// Get the image offset.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,17 @@ fn start(arg_handler: &ArgHandler) {
     // Start
     println!("Starting... (use CTRL+C to stop)");
 
-    // Gather facts about the host
-    let screen_size =
-        gather_host_facts(arg_handler).expect("Failed to gather facts about pixelflut server");
-
     // Determine the size to use
-    let size = arg_handler.size(Some(screen_size));
+    let size = if let (Some(w), Some(h)) = arg_handler.size() {
+        (w, h)
+    } else {
+        let server_canvas =
+            gather_host_facts(arg_handler).expect("Failed to gather facts about pixelflut server");
+        (
+            arg_handler.size().0.unwrap_or(server_canvas.0),
+            arg_handler.size().1.unwrap_or(server_canvas.1),
+        )
+    };
 
     // Create a new pixelflut canvas
     let mut canvas = Canvas::new(


### PR DESCRIPTION
Specifying both `--width` and `--height` allows to skip the `gather_host_facts` routine. If none or only one parameter is set, the size will be gathered from the server.

(In front of C3Heaven we have a C-implementation of pixelflut server that does not implement the `SIZE` command)