### PR TITLE
Add pixelpwnr-exporter as a relevant project

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Options:
 
 - [pixelpwnr-server][pixelpwnr-server]: server
 - [pixelpwnr-cast][pixelpwnr-cast]: cast your screen to a pixelflut server
+- [pixelpwnr-exporter](https://crates.io/crates/pixelpwnr-exporter): a prometheus metrics exporter
 
 ## License
 This project is released under the GNU GPL-3.0 license.


### PR DESCRIPTION
I wrote a simple exporter that exports the pixelpwnr stats file in a format that can be read by [Prometheus](https://prometheus.io). Figured it'd be of interest to share here.

Example grafana dashboard: https://gfa.ludd.ltu.se/public-dashboards/bf58e8fa6e124f80b2177523719be115

Link to crates.io: https://crates.io/crates/pixelpwnr-exporter